### PR TITLE
Fix: fatal crash on non-Debian hosts due to missing 'update-grub'

### DIFF
--- a/linux/ulli-linux.py
+++ b/linux/ulli-linux.py
@@ -2798,11 +2798,16 @@ as free space and offer "Install alongside existing Linux".
 def check_deps():
     missing = []
     for tool in ["parted", "rsync", "mkfs.fat",
-                 "btrfs", "blkid", "update-grub",
+                 "btrfs", "blkid",
                  "sfdisk", "resize2fs", "e2fsck", "lsblk",
                  "ntfsresize"]:
         if shutil.which(tool) is None:
             missing.append(tool)
+    # update-grub is Debian/Ubuntu-only; on other distros grub2-mkconfig or
+    # grub-mkconfig is used instead. Flag missing only if none are present.
+    grub_tools = ["update-grub", "grub2-mkconfig", "grub-mkconfig"]
+    if not any(shutil.which(t) for t in grub_tools):
+        missing.append("grub tool (one of: update-grub / grub2-mkconfig / grub-mkconfig)")
     return missing
 
 
@@ -2859,9 +2864,15 @@ if __name__ == "__main__":
         if m:
             print("Missing tools:", ", ".join(m))
             print("Install with:")
-            print("  sudo apt install " +
-                  "parted rsync dosfstools btrfs-progs grub-common "
+            print("  Debian/Ubuntu:  sudo apt install " +
+                  "parted rsync dosfstools btrfs-progs grub-common " +
                   "e2fsprogs fdisk util-linux ntfs-3g")
+            print("  Fedora/RHEL:    sudo dnf install " +
+                  "parted rsync dosfstools btrfs-progs grub2-tools " +
+                  "e2fsprogs util-linux ntfsprogs efibootmgr")
+            print("  Arch/CachyOS:   sudo pacman -S " +
+                  "parted rsync dosfstools btrfs-progs grub " +
+                  "e2fsprogs util-linux ntfs-3g efibootmgr")
         else:
             print("All dependencies satisfied.")
         sys.exit(0)


### PR DESCRIPTION
```_update_grub()``` called ```update-grub``` directly without checking whether it exists first.
On non-Debian systems like Fedora and Arch, this binary is not present which causes ```subprocess``` to raise ```FileNotFoundError```, crashing the entire installation at the final step.

This fix rewrites ```_update_grub()``` to try a prioritised list of known grub tools like ```grub2-mkconfig```, ```grub-mkconfig``` and ```update-grub``` using ```shutil.which()``` to skip any that aren't present, and falls back gracefully with manual instructions if none are found.

```check_deps()``` and the ```--check-deps``` install hints are also updated to reflect that any one grub tool satisfies the requirement, with install commands for Debian, Fedora and Arch families.

I tested on Fedora 43 as host and successfully installed CachyOS to a secondary SSD. Debian/Ubuntu behaviour is unchanged as ```update-grub``` remains in the candidate list.